### PR TITLE
65 put back temperament size and breed when getting a dog or swipe

### DIFF
--- a/sniffr/dog_routes/dog_routes.py
+++ b/sniffr/dog_routes/dog_routes.py
@@ -2,13 +2,12 @@ from concurrent.futures import process
 from datetime import datetime
 from lib2to3.pgen2 import token
 from flask import Blueprint, request, jsonify, make_response
-from sniffr.models import Dog, db, User, process_record, Breed, token_required, process_records
+from sniffr.models import Dog, db, User, Breed, token_required, process_dogs, process_dog
 import os
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 
 # Blueprint Configuration
-
 dog_bp = Blueprint("dog_bp", __name__)
 
 # Get a dog's info
@@ -19,10 +18,7 @@ def get_dog(dog_id):
     """Get dog info"""
     queried_dog = db.session.query(Dog).join(User).filter(Dog.dog_id == dog_id).first()
     if queried_dog:
-        response = process_record(queried_dog)
-        response["breed"] = queried_dog.breed.breed_name
-        response["size"] = queried_dog.size.size
-        response["temperament_type"] = queried_dog.temperament.temperament_type
+        response = process_dog(queried_dog)
 
         return response
 
@@ -44,7 +40,8 @@ def get_dogs():
     )
 
     if queried_dogs:
-        return jsonify(process_records(queried_dogs))
+        response = process_dogs(queried_dogs)
+        return jsonify(response)
 
     else:
         response = []
@@ -73,7 +70,8 @@ def get_users_dogs(current_user):
     # Return response
     response = []
     if queried_dogs:
-        return jsonify(process_records(queried_dogs))
+        response = process_dogs(queried_dogs)
+        return jsonify(response)
 
     else:
         return jsonify(response), 200
@@ -115,10 +113,7 @@ def post_dog(current_user):
 
             db.session.commit()
 
-            response = process_record(queried_dog)
-            response["breed"] = queried_dog.breed.breed_name
-            response["size"] = queried_dog.size.size
-            response["temperament_type"] = queried_dog.temperament.temperament_type
+            response = process_dog(queried_dog)
 
             return jsonify(response)
 
@@ -152,10 +147,7 @@ def post_dog(current_user):
             .filter(Dog.dog_id == new_dog.dog_id)
             .first()
         )
-        response = process_record(queried_dog)
-        response["breed"] = queried_dog.breed.breed_name
-        response["size"] = queried_dog.size.size
-        response["temperament_type"] = queried_dog.temperament.temperament_type
+        response = process_dog(queried_dog)
 
         return jsonify(response), 201
 

--- a/sniffr/match_routes/match_routes.py
+++ b/sniffr/match_routes/match_routes.py
@@ -1,6 +1,6 @@
 from lib2to3.pgen2 import token
 from flask import Blueprint, jsonify, request
-from sniffr.models import db, process_records, token_required, process_record, Match, Dog, User
+from sniffr.models import db, process_records, token_required, process_record, Match, Dog, User, process_dogs
 
 
 # Blueprint Configuration
@@ -31,5 +31,5 @@ def get_matches(current_user):
             .filter(Dog.dog_id.in_(matched_dog_ids))
             .all()
             )
-
-    return jsonify(process_records(matched_dogs))
+    response = process_dogs(matched_dogs)
+    return jsonify(response)

--- a/sniffr/models.py
+++ b/sniffr/models.py
@@ -5,7 +5,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy import inspect
 import jwt
 from functools import wraps
-from flask import request
+from flask import request, jsonify
 import os
 
 SECRET_KEY = os.getenv("SECRET_KEY")
@@ -247,3 +247,46 @@ def token_required(f):
         return  f(current_user, *args, **kwargs)
 
     return decorated
+
+def process_dogs(sqlalchemy_records):
+    records = []
+    for record in sqlalchemy_records:
+        processed_record = record.__dict__
+
+        # Add extra info
+        processed_record['breed_name'] = record.breed.breed_name
+        processed_record['temperament_type'] = record.temperament.temperament_type
+        processed_record['size'] = record.size.size
+        processed_record['owner_email'] = record.owner.email
+        processed_record['owner_name'] = record.owner.name
+
+        # Remove long annoying text
+        del processed_record["_sa_instance_state"]
+        del processed_record["breed"]
+        del processed_record["temperament"]
+        del processed_record['owner']
+
+        records.append(processed_record)
+    return records
+
+def process_dog(sqlalchemy_record):
+    records = []
+    processed_record = sqlalchemy_record.__dict__
+
+    # Add extra info
+    processed_record['breed_name'] = sqlalchemy_record.breed.breed_name
+    processed_record['temperament_type'] = sqlalchemy_record.temperament.temperament_type
+    processed_record['size'] = sqlalchemy_record.size.size
+    processed_record['owner_email'] = sqlalchemy_record.owner.email
+    processed_record['owner_name'] = sqlalchemy_record.owner.name
+
+    # Remove long annoying text
+    del processed_record["_sa_instance_state"]
+    del processed_record["breed"]
+    del processed_record["temperament"]
+    del processed_record['owner']
+    
+    records.append(processed_record)
+
+
+    return records

--- a/sniffr/models.py
+++ b/sniffr/models.py
@@ -270,7 +270,6 @@ def process_dogs(sqlalchemy_records):
     return records
 
 def process_dog(sqlalchemy_record):
-    records = []
     processed_record = sqlalchemy_record.__dict__
 
     # Add extra info
@@ -285,8 +284,6 @@ def process_dog(sqlalchemy_record):
     del processed_record["breed"]
     del processed_record["temperament"]
     del processed_record['owner']
-    
-    records.append(processed_record)
 
 
-    return records
+    return processed_record

--- a/tests/sniffr_tests/test_dogs.py
+++ b/tests/sniffr_tests/test_dogs.py
@@ -11,6 +11,7 @@ def test_get_all_dogs(test_client):
     response = test_client.get("/dogs")
     content = response.json
 
+
     # Assert
     assert response.status_code == 200
     assert len(content) == 4 # number of dogs in database at time of writing
@@ -25,6 +26,7 @@ def test_get_one_dog(test_client):
     # Register user using post request
     response = test_client.get("/dog/1")
     content = response.json
+
 
     # Assert
     assert response.status_code == 200


### PR DESCRIPTION
This PR fixes a bug affecting any route that returns dog information. Before the fix, dog-info based routes no longer returned **breed_name**, **temperament_type**, and **size**. I wrote some helper functions process this data without having to repeat code all over the place (Yay DRY). Now all routes returning dog info also return the text relating to id fields (size text to go with size id, etc)

