### PR TITLE
Complimentary matches are not showing

### DIFF
--- a/sniffr/dog_routes/dog_routes.py
+++ b/sniffr/dog_routes/dog_routes.py
@@ -60,17 +60,17 @@ def get_users_dogs(current_user):
 
     # Query and get dogs given a user id
     user_id = current_user.user_id
-    queried_dogs = (
+    queried_dog = (
         db.session.query(Dog)
         .join(User, Dog.owner_id == User.user_id)
         .filter(Dog.owner_id == user_id)
-        .all()
+        .first()
     )
 
     # Return response
-    response = []
-    if queried_dogs:
-        response = process_dogs(queried_dogs)
+    response = {}
+    if queried_dog:
+        response = process_dog(queried_dog)
         return jsonify(response)
 
     else:

--- a/sniffr/match_routes/match_routes.py
+++ b/sniffr/match_routes/match_routes.py
@@ -1,6 +1,6 @@
 from lib2to3.pgen2 import token
 from flask import Blueprint, jsonify, request
-from sniffr.models import db, process_records, token_required, process_record, Match, Dog, User, process_dogs
+from sniffr.models import db, get_users_dogs_id, token_required, Match, Dog, User, process_dogs
 
 
 # Blueprint Configuration
@@ -14,22 +14,25 @@ def get_matches(current_user):
     # THEN return all dogs that are matches
 
     user_id = int(current_user.user_id)
+    users_dog_id = get_users_dogs_id(user_id)
 
     past_matches = (
         db.session.query(Match)
-        .join(Dog, Match.dog_id_one == Dog.dog_id)  
-        .filter(Dog.owner_id == user_id)
+        .filter((Match.dog_id_two == users_dog_id) | (Match.dog_id_one == users_dog_id))
         .all()
     )
 
-    # Return list of dogs that are matches
-    matched_dog_ids = [match.dog_id_two for match in past_matches]
+    matched_dog_ids1 = list(set([matched_dog.dog_id_one for matched_dog in past_matches]))
+    matched_dog_ids2 = list(set([matched_dog.dog_id_two for matched_dog in past_matches]))
+    matched_dog_ids = matched_dog_ids1 + matched_dog_ids2
+
     matched_dogs = (
             db.session.query(Dog)
             .join(User, Dog.owner_id == User.user_id)
-            .filter(Dog.owner_id != user_id)
             .filter(Dog.dog_id.in_(matched_dog_ids))
+            .filter(Dog.dog_id != users_dog_id)
             .all()
             )
+
     response = process_dogs(matched_dogs)
     return jsonify(response)

--- a/sniffr/models.py
+++ b/sniffr/models.py
@@ -287,3 +287,15 @@ def process_dog(sqlalchemy_record):
 
 
     return processed_record
+
+
+def get_users_dogs_id(user_id):
+    queried_dog = (
+        db.session.query(Dog)
+        .join(User, Dog.owner_id == User.user_id)
+        .filter(Dog.owner_id == user_id)
+        .first()
+    )
+
+    # Return id
+    return int(queried_dog.dog_id)


### PR DESCRIPTION
# PROBLEM: If AUGIE likes CERBERUS and then CERBERUS likes AUGIE... only AUGIE will show a match. The complimentary view of the match is not showing.

Now it is :)
using the /matches route:

## Cerberus's matches showing Augie (and another) on local
![image](https://user-images.githubusercontent.com/57068081/193185134-2db15873-78de-4cc1-be94-280b3cecce28.png)

## and the opposite view-- Augie's matches showing Cerberus (and another) on local
![image](https://user-images.githubusercontent.com/57068081/193185265-014c589a-b55a-417d-b7c4-0ef37e9123d2.png)
